### PR TITLE
Added HELM to KitType

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/kit/KitType.java
+++ b/runelite-api/src/main/java/net/runelite/api/kit/KitType.java
@@ -36,6 +36,7 @@ import net.runelite.api.PlayerComposition;
  */
 public enum KitType
 {
+	HELM(0),
 	CAPE(1),
 	AMULET(2),
 	WEAPON(3),


### PR DESCRIPTION
Previous implementation started with CAPE(1), but was missing 0 index which handles the HELM. It should be noted that in my testing, HEAD(8) and JAW(11) always return -1, so they might be useless.